### PR TITLE
Add JavaScript packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ Install protocol buffer library
 
 #### Javascript
 ```bash
-  npm install shipthisnx-protobufs
+npm install git+https://github.com/shipthisco/gRPC-protobuf.git
 ```
 
 #### Python
 
 ```bash
-  pip3 install shipthisnx-protobufs
+pip install git+https://github.com/shipthisco/gRPC-protobuf.git
+```
+
+To build the JavaScript package locally, the script `scripts/javascript/generate_lib.js`
+relies on `grpc_tools_node_protoc`. Install it globally or use `npx` when running
+the script:
+
+```bash
+npm install -g grpc-tools  # optional
 ```
     
 

--- a/scripts/javascript/generate_lib.js
+++ b/scripts/javascript/generate_lib.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const DEFAULT_VERSION = '1.1.8';
+const VERSION = process.argv[2] || DEFAULT_VERSION;
+
+const distFolder = 'jsshipproto';
+const currentDir = __dirname;
+const packageFolder = path.join(currentDir, '..', '..', 'protobuf');
+const distPath = path.join(currentDir, distFolder);
+
+if (!fs.existsSync(distPath)) {
+  fs.mkdirSync(distPath);
+}
+
+function findProtoc() {
+  try {
+    execSync('command -v grpc_tools_node_protoc', { stdio: 'ignore' });
+    return 'grpc_tools_node_protoc';
+  } catch (_) {
+    return 'npx grpc_tools_node_protoc';
+  }
+}
+
+const PROTOC_CMD = findProtoc();
+
+function gatherProtos(dir) {
+  const results = [];
+  const list = fs.readdirSync(dir);
+  list.forEach(file => {
+    const fullPath = path.join(dir, file);
+    if (fs.statSync(fullPath).isDirectory()) {
+      results.push(...gatherProtos(fullPath));
+    } else if (file.endsWith('.proto')) {
+      results.push(fullPath);
+    }
+  });
+  return results;
+}
+
+const protoFiles = gatherProtos(packageFolder);
+
+protoFiles.forEach(proto => {
+  const command = [
+    PROTOC_CMD,
+    `--js_out=import_style=commonjs,binary:${distPath}`,
+    `--grpc_out=${distPath}`,
+    `-I${packageFolder}`,
+    proto
+  ].join(' ');
+  execSync(command, { stdio: 'inherit' });
+});
+
+const exportsLines = protoFiles.map(p => {
+  const name = path.basename(p, '.proto');
+  return `exports.${name} = require('./${name}_pb');`;
+});
+fs.writeFileSync(path.join(distPath, 'index.js'), exportsLines.join('\n'));
+
+const packageJson = {
+  name: 'jsshipproto',
+  version: VERSION,
+  description: 'JsShipProto package with generated gRPC services.',
+  main: 'index.js',
+  keywords: ['javascript', 'gRPC', 'protobuf', 'jsshipproto'],
+  author: 'JsShipProto',
+  license: 'ISC',
+};
+fs.writeFileSync(
+  path.join(distPath, 'package.json'),
+  JSON.stringify(packageJson, null, 2)
+);
+
+execSync(`npm pack ${distPath}`, { stdio: 'inherit' });
+


### PR DESCRIPTION
## Summary
- add `generate_lib.js` script to create a JavaScript package from protobufs
- check for `grpc_tools_node_protoc` or fallback to `npx`
- document installing packages from GitHub and mention `grpc-tools`

## Testing
- `node --check scripts/javascript/generate_lib.js`
- `python3 -m py_compile scripts/python/generate_lib.py`


------
https://chatgpt.com/codex/tasks/task_b_684165963c3c832a8f2b12ebbddfb8ed