### PR TITLE
Publish JavaScript package to npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,30 @@ jobs:
 
       - name: Release (Optional)
         run: echo "🚀 Release to PyPI is handled automatically with twine upload."
+
+  BuildJavaScript:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Generate Library
+        run: |
+          cd scripts/javascript
+          node generate_lib.js ${{ env.VERSION }}
+
+      - name: Publish to npm
+        run: npm publish scripts/javascript/jsshipproto-${{ env.VERSION }}.tgz --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Release (Optional)
+        run: echo "📦 JavaScript package published"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install protocol buffer library
 
 #### Javascript
 ```bash
-npm install git+https://github.com/shipthisco/gRPC-protobuf.git
+npm install jsshipproto
 ```
 
 #### Python


### PR DESCRIPTION
## Summary
- publish JavaScript package to npm from GitHub Actions
- update install instructions for npm

## Testing
- `python -m py_compile scripts/python/generate_lib.py`
- `node --check scripts/javascript/generate_lib.js`
- `node scripts/javascript/generate_lib.js 1.2.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6841676e0b7c832a9ce73bd0f2422240