### PR TITLE
Fix JS generation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ pip install git+https://github.com/shipthisco/gRPC-protobuf.git
 
 ## 🛠️ Building from source
 
-To generate the JavaScript package locally, ensure `grpc_tools_node_protoc` is available globally or run via `npx`:
+To generate the JavaScript package locally, ensure `grpc_tools_node_protoc` is available globally or let the script fetch it with `npx`:
 
 ```bash
 npm install -g grpc-tools # optional
 node scripts/javascript/generate_lib.js <version>
+# The script will use `npx -p grpc-tools` automatically if the tool isn't installed.
 ```
 
 For Python packages run:

--- a/scripts/javascript/generate_lib.js
+++ b/scripts/javascript/generate_lib.js
@@ -19,7 +19,8 @@ function findProtoc() {
     execSync('command -v grpc_tools_node_protoc', { stdio: 'ignore' });
     return 'grpc_tools_node_protoc';
   } catch (_) {
-    return 'npx grpc_tools_node_protoc';
+    // Explicitly install grpc-tools via npx so the correct binary is used
+    return 'npx -p grpc-tools grpc_tools_node_protoc';
   }
 }
 


### PR DESCRIPTION
## Summary
- fix JS generator to explicitly install grpc-tools
- clarify README instructions about npx

## Testing
- `node -e "require('./scripts/javascript/generate_lib.js');"` *(fails: 403 Forbidden fetching npm packages)*
- `go vet ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_b_68416d47e618832a80aa921ae6b673ad