### PR TITLE
Switch JS stubs to grpc-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To generate the JavaScript package locally, ensure `grpc_tools_node_protoc` is a
 npm install -g grpc-tools # optional
 node scripts/javascript/generate_lib.js <version>
 # The script will use `npx -p grpc-tools` automatically if the tool isn't installed.
+# Generated stubs rely on `@grpc/grpc-js` as the runtime implementation.
 ```
 
 For Python packages run:

--- a/scripts/javascript/generate_lib.js
+++ b/scripts/javascript/generate_lib.js
@@ -46,7 +46,8 @@ protoFiles.forEach(proto => {
   const command = [
     PROTOC_CMD,
     `--js_out=import_style=commonjs,binary:${distPath}`,
-    `--grpc_out=${distPath}`,
+    // Generate code compatible with @grpc/grpc-js instead of the deprecated grpc package
+    `--grpc_out=grpc_js:${distPath}`,
     `-I${packageFolder}`,
     proto
   ].join(' ');
@@ -67,6 +68,10 @@ const packageJson = {
   keywords: ['javascript', 'gRPC', 'protobuf', 'jsshipproto'],
   author: 'JsShipProto',
   license: 'ISC',
+  // Use the modern @grpc/grpc-js runtime instead of the deprecated grpc package
+  dependencies: {
+    '@grpc/grpc-js': '^1.8.0'
+  }
 };
 fs.writeFileSync(
   path.join(distPath, 'package.json'),


### PR DESCRIPTION
## Summary
- generate JavaScript grpc stubs using `@grpc/grpc-js`
- declare `@grpc/grpc-js` as a dependency for the generated package
- note grpc-js runtime in README

## Testing
- `node --check scripts/javascript/generate_lib.js`

------
https://chatgpt.com/codex/tasks/task_b_684277991584832aa9e234623f93c668